### PR TITLE
update default styles

### DIFF
--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -62,6 +62,10 @@ body {
     margin: 0px 0px 20px 0px;
 }
 
+#fsdocs-content li {
+    margin: 0px 0px 15px 0px;
+}
+
 /*--------------------------------------------------------------------------
   Formatting tables in fsdocs-content, using docs.microsoft.com tables
 /*--------------------------------------------------------------------------*/
@@ -99,8 +103,8 @@ body {
     }
 
     /* suppress the top line on inner lists such as tables of exceptions */
-    #fsdocs-content .table .inner-list td,
-    #fsdocs-content .table .inner-list th {
+    #fsdocs-content .table .fsdocs-exception-list td,
+    #fsdocs-content .table .fsdocs-exception-list th {
         border-top: 0
     }
 
@@ -308,10 +312,10 @@ body {
 /*--------------------------------------------------------------------------*/
 
 #fsdocs-logo {
-    width:140px;
-    height:140px;
-    margin:10px 0px 0px 0px;
-    border-style:none;
+    width: 140px;
+    height: 140px;
+    margin: 10px 0px 0px 0px;
+    border-style: none;
 }
 
 /*--------------------------------------------------------------------------


### PR DESCRIPTION

This updates the default styles for latest FSharp.Formatting and will also pick up the latest FSharp.Core and FSharp.Formatting changes

* https://github.com/dotnet/fsharp/pull/9880/ -  Improve docs for FSharp.Core
* https://github.com/fsprojects/FSharp.Formatting/pull/580 - Add XML doc support for categorization and exclusions

With these the docs for FSHarp.Core namespace look much nicer:


![image](https://user-images.githubusercontent.com/7204669/89474633-12d4ab80-d77e-11ea-88da-d965b5294627.png)

