### PR TITLE
warn on missing docs and get latest FSharp.Core content and F#F tooling

### DIFF
--- a/FSharp.Core/FSharp.Core.fsproj
+++ b/FSharp.Core/FSharp.Core.fsproj
@@ -36,6 +36,7 @@
     <FsDocsReleaseNotesLink>https://github.com/dotnet/fsharp/blob/master/release-notes.md</FsDocsReleaseNotesLink>
     <RepositoryType>git</RepositoryType>
     <FsDocsNavbarPosition>fixed-left</FsDocsNavbarPosition>
+    <FsDocsWarnOnMissingDocs>true</FsDocsWarnOnMissingDocs>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This adds warnings for missing docs on FSharp.Core.

Also get the latest FSharp.Core content that adds categorization to `FSharp.Control` and `Async` - both look much better now

Also get latest F#F tooling that adjusts for https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1031-xmldoc-extensions.md
