### PR TITLE
add manual push workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This allows for manual triggering of the build/deploy workflow from any branch.

To kick off a new build, go to the 'Actions' tab, choose the 'Release docs' job, and use the 'trigger workflow' button on the top-right to trigger a new job from master.