### PR TITLE
Use 'main' from 'dotnet/fsharp'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Restore projects
       run: dotnet restore FSharp.Core\FSharp.Core.fsproj
     - name: Checkout fsharp master
-      run: git clone https://github.com/dotnet/fsharp --depth 1 fsharp -b feature/docs
+      run: git clone https://github.com/dotnet/fsharp --depth 1 fsharp -b main
     - name: Build fsharp master (turn of CI build status)
       run: cd fsharp && eng\CIBuild.cmd
     - name: Checkout FSharp.Formatting master

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Eventually the build will just be
 
 For now, we want to pick up the latest copies of FSharp.Formatting and FSharp.Core, and set you up to make contributions to these. So we ask you to clone local copies of these:
 
-    git clone https://github.com/dotnet/fsharp --depth 1 -b feature/docs
-    git clone https://github.com/fsprojects/FSharp.Formatting
+    git clone https://github.com/dotnet/fsharp --depth 1 -b main
+    git clone https://github.com/fsprojects/FSharp.Formatting --depth 1
     pushd fsharp
     .\build -noVisualStudio
     popd


### PR DESCRIPTION

The `feature/docs` branch keeps getting deleted from `dotnet/fsharp` so unfortunately we have to pick up FSharp.Core doc content from `main`.

This is not to my liking as it makes it harder for us to iterate on fixes to docs, as we're gated on fixes being pulled to that branch.

But it is what it is, so for now we will use `dotnet/fsharp` main.  I will switch to pick up FSharp.Core from a branch in `dsyme` next time I iterate on the doc content.



