### PR TITLE
Update F# Asynchronous Programming link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ The following namespaces are available:
 
 * [FSharp.Collections](reference/fsharp-collections.html) - Operations for collections such as lists, arrays, sets, maps and sequences. See also [F# Collection Types](https://docs.microsoft.com/dotnet/fsharp/language-reference/fsharp-collection-types) in the F# Language Guide.
 
-* [FSharp.Control](reference/fsharp-control.html) - Library functionality for asynchronous programming, events and agents. See also [F# Asynchronous Programming](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/asynchronous-workflows) in the F# Language Guide.
+* [FSharp.Control](reference/fsharp-control.html) - Library functionality for asynchronous programming, events and agents. See also [F# Asynchronous Programming](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/async-expressions) in the F# Language Guide.
 
 * [FSharp.Linq](reference/fsharp-linq.html) - Library functionality for F# query syntax and interoperability with .NET Expressions. See also [F# Query Expressions](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/query-expressions) in the F# Language Guide.
 


### PR DESCRIPTION
The current link in the `FSharp.Control` section of the index redirects to a link that does not exist anymore. Not completely sure what the link originally included, but I guess that [Async and Task Programming docs](https://docs.microsoft.com/en-us/dotnet/fsharp/tutorials/async) should be the correct one.