### PR TITLE
Revert bump dotnet version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        dotnet: [6.0.302]
+        dotnet: [6.0.203]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.302
+          dotnet-version: 6.0.203
       - name: Restore tools
         run: dotnet tool restore
       - name: Restore projects

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        dotnet: [6.0.302]
+        dotnet: [6.0.203]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.302
+          dotnet-version: 6.0.203
       - name: Restore tools
         run: dotnet tool restore
       - name: Restore projects

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Build FSharp.Formatting master
         run: cd FSharp.Formatting && .\build -t Build
       - name: Run fsdocs
-        run: dotnet FSharp.Formatting\src\fsdocs-tool\bin\Release\net5.0\fsdocs.dll build --sourcefolder fsharp
+        run: dotnet FSharp.Formatting\src\fsdocs-tool\bin\Release\net6.0\fsdocs.dll build --sourcefolder fsharp


### PR DESCRIPTION
[FSharp.Formatting](https://github.com/fsprojects/FSharp.Formatting) don't have `dotnet 6.0.302`.
I have put back the previous version `6.0.203`.