### PR TITLE
Only build FSharp.Core

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,8 +37,8 @@ jobs:
           repository: dotnet/fsharp
           path: ${{ env.FSHARP_DIR }}
           ref: main
-      - name: Build fsharp main (turn of CI build status)
-        run: eng\CIBuild.cmd -noVisualStudio
+      - name: Build FSharp.Core in fsharp main
+        run: dotnet build .\src\FSharp.Core\ /p:BUILDING_USING_DOTNET=true
         working-directory: ${{ env.FSHARP_DIR }}
       - name: Checkout FSharp.Formatting main
         uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,8 +32,8 @@ jobs:
           repository: dotnet/fsharp
           path: ${{ env.FSHARP_DIR }}
           ref: main
-      - name: Build fsharp main (turn of CI build status)
-        run: eng\CIBuild.cmd -noVisualStudio
+      - name: Build FSharp.Core in fsharp main
+        run: dotnet build .\src\FSharp.Core\ /p:BUILDING_USING_DOTNET=true
         working-directory: ${{ env.FSHARP_DIR }}
       - name: Checkout FSharp.Formatting main
         uses: actions/checkout@v3


### PR DESCRIPTION
Due to the change of https://github.com/dotnet/fsharp/pull/14677 we should be able to build the docs by only building FSharp.Core.